### PR TITLE
XML InvariantCulture fix

### DIFF
--- a/src/Assets/Plugins/Uniject/Util/XMLConfigurationManager.cs
+++ b/src/Assets/Plugins/Uniject/Util/XMLConfigurationManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
@@ -46,7 +47,7 @@ namespace Uniject.Configuration {
             if (null == element) {
                 throw new ArgumentException("Xpath element not found:" + xpath);
             }
-            return (T)(Convert.ChangeType(element.Value, typeof(T)));
+            return (T)(Convert.ChangeType(element.Value, typeof(T), CultureInfo.InvariantCulture));
         }
     }
 }


### PR DESCRIPTION
Added CultureInfo.InvariantCulture to the Convert.ChangeType call in XMLConfigurationManager.cs, now handling xml data culture-insensitive, it is now associated with the English language but not with any country/region.

http://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.invariantculture.aspx
