### PR TITLE
Support for Start() method that fires after constructor but before the first Update()

### DIFF
--- a/src/Assets/Plugins/Uniject/impl/TestableComponent.cs
+++ b/src/Assets/Plugins/Uniject/impl/TestableComponent.cs
@@ -22,6 +22,9 @@ namespace Uniject {
             }
         }
 
+        public virtual void Start() {
+        }
+
         public virtual void Update() {
         }
 

--- a/src/Assets/Plugins/Uniject/impl/TestableGameObject.cs
+++ b/src/Assets/Plugins/Uniject/impl/TestableGameObject.cs
@@ -33,6 +33,13 @@ namespace Uniject {
             }
         }
 
+        public void Start() {
+            for (int t = 0; t < components.Count; t++) {
+                TestableComponent component = components[t];
+                component.Start();
+            }
+        }
+
         public void Update() {
             if (active) {
                 for (int t = 0; t < components.Count; t++) {

--- a/src/Assets/Plugins/Uniject/impl/UnityGameObjectBridge.cs
+++ b/src/Assets/Plugins/Uniject/impl/UnityGameObjectBridge.cs
@@ -3,6 +3,11 @@ using Uniject.Impl;
 using UnityEngine;
 
 public class UnityGameObjectBridge : MonoBehaviour {
+
+    public void Start() {
+        wrapping.Start();
+    }
+
     public void OnDestroy() {
         wrapping.Destroy();
     }

--- a/src/test/tests/src/Impl/framework/TestUpdatableManager.cs
+++ b/src/test/tests/src/Impl/framework/TestUpdatableManager.cs
@@ -12,6 +12,7 @@ namespace Tests {
 
                 foreach (TestableGameObject o in toAdd) {
                     objects.Add(o);
+                    o.Start();
                 }
                 toAdd.Clear();
 

--- a/src/test/tests/src/Tests/TestUniject.cs
+++ b/src/test/tests/src/Tests/TestUniject.cs
@@ -55,6 +55,23 @@ namespace Tests {
             }
         }
 
+        public interface IStartUpdateCallback {
+            void OnConstructor();
+            void OnStart();
+            void OnUpdate();
+        }
+
+        [GameObjectBoundary]
+        public class HasStartUpdateCallback : TestableComponent {
+            public IStartUpdateCallback callback;
+            public HasStartUpdateCallback(TestableGameObject obj, IStartUpdateCallback callback) : base(obj) {
+                this.callback = callback;
+                this.callback.OnConstructor();
+            }
+            public override void Start() { callback.OnStart(); }
+            public override void Update() { callback.OnUpdate(); }
+        }
+
         /// <summary>
         /// Tests the testable component has its Update method called.
         /// </summary>
@@ -65,6 +82,32 @@ namespace Tests {
             Assert.AreEqual(0, component.updateCount);
             step(1);
             Assert.AreEqual(1, component.updateCount);
+        }
+
+        /// <summary>
+        /// Tests that the testable component has its constructor called
+        /// first, its Start method second, and its Update method last.
+        /// </summary>
+        [Test]
+        public void TestTestableComponentStartFiresBeforeUpdate()
+        {
+            Mock<IStartUpdateCallback> mockCallback = new Mock<IStartUpdateCallback>();
+            mockCallback.Setup(c => c.OnConstructor()).Callback(() => {
+                mockCallback.Verify(c => c.OnStart(), Times.Never());
+                mockCallback.Verify(c => c.OnUpdate(), Times.Never());
+            });
+            mockCallback.Setup(c => c.OnStart()).Callback(() => {
+                mockCallback.Verify(c => c.OnConstructor(), Times.Once());
+                mockCallback.Verify(c => c.OnUpdate(), Times.Never());
+            });
+            mockCallback.Setup(c => c.OnUpdate()).Callback(() => {
+                mockCallback.Verify(c => c.OnConstructor(), Times.Once());
+                mockCallback.Verify(c => c.OnStart(), Times.Once());
+            });
+
+            kernel.Bind<IStartUpdateCallback>().ToMethod(context => mockCallback.Object);
+            HasStartUpdateCallback component = kernel.Get<HasStartUpdateCallback>();
+            step();
         }
 
         [Test]


### PR DESCRIPTION
Adds an optional overridable Start() method on TestableComponent that will be called after the constructor but before the first Update(). Included a test for verification.

The purpose of this is to allow authors to write Component classes that feel more like they inherited from MonoBehaviour. It is also sometimes desirable to guarantee that code executes after Awake() (which in this case is simulated by the constructor).

I'd like to add support for Awake() but can't see a viable way to do it with injection (Awake must be called after all objects are initialized).
